### PR TITLE
docs: add repository documentation and editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+max_line_length = 100
+
+[*.{java,kt,kts}]
+indent_size = 4
+continuation_indent_size = 4
+
+[*.{ts,tsx,js,jsx,json,cjs,mjs}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thank you for helping improve the Health Risk Dashboard! This guide covers how we work together across the backend and frontend projects.
+
+## Development workflow
+1. Discuss significant changes via an issue or architecture note before writing code.
+2. Fork the repo (if external) and create a dedicated branch from `main` (see branching model below).
+3. Keep changes focused: separate backend, frontend, and infrastructure updates into logical commits.
+4. Ensure all automated checks pass locally before requesting a review.
+
+## Commit style
+We follow [Conventional Commits](https://www.conventionalcommits.org/) to keep a clean history and automate changelog generation.
+
+- Use the format `<type>(optional scope): <summary>` (e.g., `feat(frontend): add risk trends chart`).
+- Keep summaries under 72 characters and use the imperative mood.
+- Include body and footer details when they add context (e.g., breaking changes, issue references).
+
+Common commit types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `ci`.
+
+## Branching model
+- `main` is always releasable; it holds production-ready code.
+- Create short-lived branches off `main` using a descriptive prefix:
+  - `feature/<summary>` for new features
+  - `bugfix/<summary>` for fixes
+  - `chore/<summary>` for maintenance tasks
+- Rebase your branch onto the latest `main` before opening a pull request.
+- Delete feature branches after merging to keep the repository tidy.
+
+## Pull request checklist
+Before requesting review:
+- [ ] Ensure commits follow the Conventional Commits standard.
+- [ ] Update documentation, changelog entries, or configuration files touched by the change.
+- [ ] Add or update automated tests and confirm they pass (`./gradlew test`, `pnpm test`).
+- [ ] Run linters/formatters as applicable (e.g., `./gradlew check`, `pnpm lint`, `pnpm format`).
+- [ ] Verify build artifacts: `./gradlew bootJar` for backend, `pnpm build` for frontend.
+- [ ] Confirm no secrets or sensitive data are present in the code or configuration.
+- [ ] Request reviewers who own the affected area and provide context for manual testing when needed.
+
+## Code review expectations
+- Authors respond promptly to feedback and keep discussions respectful.
+- Reviewers focus on correctness, maintainability, security, and developer experience.
+- Small follow-up issues can be tracked with TODOs or separate tasks; blocking items must be addressed before merge.
+- Use squash merge for PRs to maintain a linear history (the squash commit must still follow Conventional Commit format).
+
+## Releasing
+- Tag releases from `main` (e.g., `v1.2.0`) after CI passes.
+- Document release notes summarizing key backend and frontend changes.
+
+Happy building!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Health Risk Dashboard Monorepo
+
+## Overview
+Health Risk Dashboard is a monorepo that combines a Spring Boot backend and a React + TypeScript frontend to deliver health analytics features in a single deployable stack. The repository is designed to keep shared conventions, tooling, and automation in one place so both applications can evolve together.
+
+## Tech stack
+- **Backend:** Java 21, Spring Boot, Gradle Wrapper.
+- **Frontend:** React, TypeScript, Vite, PNPM.
+- **Common tooling:** EditorConfig, Conventional Commits, GitHub Actions (planned).
+
+## Repository structure
+```
+/                        # Monorepo root with shared tooling and docs
+├─ backend/              # Spring Boot application (Java 21)
+└─ frontend/             # React + TypeScript + Vite single-page app
+```
+
+## Prerequisites
+- Java Development Kit (JDK) 21
+- Node.js 18+ (Corepack recommended)
+- PNPM 8+ (`corepack enable` to manage automatically)
+- Docker (optional) for local infrastructure dependencies
+
+## Getting started
+1. Clone the repository and install toolchain prerequisites.
+2. Enable the PNPM package manager:
+   ```bash
+   corepack enable
+   ```
+3. Install frontend dependencies and start the dev server:
+   ```bash
+   cd frontend
+   pnpm install
+   pnpm dev
+   ```
+4. Build and run the backend service:
+   ```bash
+   cd backend
+   ./gradlew bootRun
+   ```
+
+## Testing
+- **Backend:** `./gradlew test`
+- **Frontend:** `pnpm test`
+
+## Continuous integration
+Automated workflows should validate formatting, linting, tests, and build steps for both applications. Add shared CI configurations in the repository root (e.g., `.github/workflows/`).
+
+## Contributing
+Refer to [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions, branch naming, and the review checklist.


### PR DESCRIPTION
## Summary
- add a root README that outlines the monorepo structure and local setup commands
- document contribution guidelines covering workflow, commit style, and branching model
- define a shared EditorConfig to align formatting rules across backend and frontend code

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ceff1a795c8333a11c09bea16415c6